### PR TITLE
fix: match scoped feat() in MINOR regex

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ get_bump_level_from_git_commit_messages() {
   # major > minor > patch
   while read -r line; do
     REGEX_MAJOR="(^(((#major)|([[:alnum:]][[:alnum:]\/\-_]+(\([[:alnum:]][[:alnum:]\/\-_:]+\))?)!):)|(BREAKING CHANGE:))"
-    REGEX_MINOR="^(#minor|feat:)"
+    REGEX_MINOR="^(#minor|feat(\([[:alnum:]][[:alnum:]\/\-_:]+\))?:)"
     if [[ "$line" =~ $REGEX_MAJOR ]]; then
       bump_major=true
     elif [[ "$line" =~ $REGEX_MINOR ]]; then


### PR DESCRIPTION
The MINOR regex required a bare `feat:` prefix, so a Conventional Commit-styled scoped feature (e.g. `feat(api): add endpoint`) matched neither MAJOR (no `!`) nor MINOR (scope group blocked it) and silently fell through to PATCH.

Mirror the optional-scope group already used in the MAJOR regex so `feat(<scope>):` correctly bumps MINOR while every other behaviour (plain `feat:`, `feat!:`, `feat(scope)!:`, `BREAKING CHANGE:`, `#minor`) is preserved.