### PR TITLE
fix: align MAJOR regex with spec + restore #major escape hatch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ get_bump_level_from_git_commit_messages() {
   # to determine symantic bump level
   # major > minor > patch
   while read -r line; do
-    REGEX_MAJOR="(^(((#major)|([[:alnum:]][[:alnum:]\/\-_]+(\([[:alnum:]][[:alnum:]\/\-_:]+\))?)!):)|(BREAKING CHANGE:))"
+    REGEX_MAJOR="(^#major|^[[:alnum:]][[:alnum:]\/\-_]+(\([[:alnum:]][[:alnum:]\/\-_:]+\))?!:|BREAKING[ -]CHANGE:)"
     REGEX_MINOR="^(#minor|feat(\([[:alnum:]][[:alnum:]\/\-_:]+\))?:)"
     if [[ "$line" =~ $REGEX_MAJOR ]]; then
       bump_major=true


### PR DESCRIPTION
Two issues addressed:

1. The previous structure grouped `#major` inside the colon-requiring branch of the alternation, so the bare `#major` marker (used as a manual override) only matched when written as `#major:`. The sibling MINOR regex has always treated `#minor` as colon-optional, so this was an inconsistency as well as a usability paper-cut. Move `#major` to its own anchored alternative.

2. Conventional Commits 1.0.0 states `BREAKING CHANGE` and `BREAKING-CHANGE` are equivalent footer tokens. The regex matched only the space form. Use `BREAKING[ -]CHANGE:` to accept either.

Behaviour preserved: `<type>!:` and `<type>(scope)!:` still trigger MAJOR; plain `<type>:` / `<type>(scope):` still do not. Verified against the full Conventional Commits matrix plus the #major/#minor escape hatches.